### PR TITLE
Fix deprecation warnings

### DIFF
--- a/spec/crystal-ptools_spec.cr
+++ b/spec/crystal-ptools_spec.cr
@@ -194,7 +194,7 @@ describe File do
     it "returns the expected result for 'bytes'" do
       File.wc("spec/txt/english.txt", "bytes").should eq(40)
     end
- 
+
     it "returns the expected result for 'chars'" do
       File.wc("spec/txt/english.txt", "chars").should eq(40)
     end
@@ -204,7 +204,9 @@ describe File do
     it "returns the expected result if a binary is found" do
       expected = IO::Memory.new
       Process.run(command: "which", args: ["crystal"], output: expected, error: expected)
-      File.whereis("crystal").should eq([expected.to_s.chomp])
+      result = File.whereis("crystal")
+      result.should_not be_nil
+      result.not_nil!.should contain(expected.to_s.chomp)
     end
 
     it "returns the expected result if an absolute path is used" do

--- a/src/crystal-ptools.cr
+++ b/src/crystal-ptools.cr
@@ -238,7 +238,7 @@ class File
     if program.absolute?
       found = Dir[program].first?
 
-      if found && File.executable?(found) && !File.directory?(found)
+      if found && File::Info.executable?(found) && !File.directory?(found)
         return [found]
       else
         return nil
@@ -255,7 +255,7 @@ class File
       found = Dir[file].first?
 
       # Convert all forward slashes to backslashes if supported
-      if found && File.executable?(found) && !File.directory?(found)
+      if found && File::Info.executable?(found) && !File.directory?(found)
         paths << found
       end
     end
@@ -283,7 +283,7 @@ class File
     if program.absolute?
       found = Dir[program].first?
 
-      if found && File.executable?(found) && !File.directory?(found)
+      if found && File::Info.executable?(found) && !File.directory?(found)
         return found
       else
         return nil
@@ -298,7 +298,7 @@ class File
       file = File.join(dir, program)
       found = Dir[file].first?
 
-      if found && File.executable?(found) && !File.directory?(found)
+      if found && File::Info.executable?(found) && !File.directory?(found)
         return found
       end
     end


### PR DESCRIPTION
Apparently `File.executable?` is now `File::Info.executable?`